### PR TITLE
Show current language in the mode line

### DIFF
--- a/guess-language.el
+++ b/guess-language.el
@@ -202,7 +202,7 @@ correctly."
   ;; The initial value.
   :init-value nil
   ;; The indicator for the mode line.
-  :lighter '(:eval (format " (%s)" (or ispell-local-dictionary "default")))
+  :lighter (:eval (format " (%s)" (or ispell-local-dictionary "default")))
   :global nil
   :group 'guess-language
   (if guess-language-mode

--- a/guess-language.el
+++ b/guess-language.el
@@ -202,7 +202,7 @@ correctly."
   ;; The initial value.
   :init-value nil
   ;; The indicator for the mode line.
-  :lighter " Guess-lang"
+  :lighter '(:eval (format " (%s)" (or ispell-local-dictionary "default")))
   :global nil
   :group 'guess-language
   (if guess-language-mode


### PR DESCRIPTION
The current `:lighter` for `guess-language-mode` is rather long and uninformative. By using `:eval`, it can be made much more informative.