### PR TITLE
Fix hook initialization

### DIFF
--- a/guess-language.el
+++ b/guess-language.el
@@ -105,7 +105,7 @@ value is nil."
   :type '(alist :key-type symbol :value-type list)
   :group 'guess-language)
 
-(defcustom guess-language-after-detection-functions (list #'guess-language-switch-flyspell-function)
+(defcustom guess-language-after-detection-functions '()
   "Hook run when a new language is detected.
 
 This hook is abnormal in that its functions take arguments,
@@ -240,6 +240,10 @@ correctly."
   (if guess-language-mode
       (add-hook 'flyspell-incorrect-hook #'guess-language-function nil t)
     (remove-hook 'flyspell-incorrect-hook #'guess-language-function t)))
+
+
+;;;###autoload
+(add-hook 'guess-language-after-detection-functions 'guess-language-switch-flyspell-function)
 
 (provide 'guess-language)
 


### PR DESCRIPTION
After adding my custom function to the hook `guess-language-switch-flyspell-function` would never get called. Try to initialize the hook as suggested in this commit and see if it improves the behavior.