### PR TITLE
Use regexp-opt for compiling regexps

### DIFF
--- a/guess-language.el
+++ b/guess-language.el
@@ -148,8 +148,7 @@ Uses ISO 639-1 to identify languages.")
   (setq guess-language--regexps
         (cl-loop
          for lang in (guess-language-load-trigrams)
-         for regexp = (mapconcat 'identity (cdr lang) "\\|")
-         collect (cons (car lang) regexp))))
+         collect (cons (car lang) (regexp-opt (cdr lang))))))
 
 (defun guess-language-backward-paragraph ()
   "Uses whatever method for moving to the previous paragraph is


### PR DESCRIPTION
This should lead to improved performance in most cases.

I have done one benchmark.
With `guess-language-languages` = `(en sv)`, loading [this ebook](http://www.gutenberg.org/cache/epub/12352/pg12352.txt) in a buffer, `(benchmark-run 10 (guess-language-region (point-min) (point-max)))` gives
````
(5.655183475 0 0.0)
````
for the regexps compiled with `regexp-opt` and
````
(40.887046829 0 0.0)
````
for the old `mapconcat` regexps.

From what I’ve learned, `regexp-opt` is usually the way to go.

