### PR TITLE
Use destructuring in cl-loop variable assignments

### DIFF
--- a/guess-language.el
+++ b/guess-language.el
@@ -148,8 +148,7 @@ Uses ISO 639-1 to identify languages.")
   (setq guess-language--regexps
         (cl-loop
          for lang in (guess-language-load-trigrams)
-         for regexp = (mapconcat 'identity (cdr lang) "\\|")
-         collect (cons (car lang) regexp))))
+         collect (cons (car lang) (regexp-opt (cdr lang))))))
 
 (defun guess-language-backward-paragraph ()
   "Uses whatever method for moving to the previous paragraph is

--- a/guess-language.el
+++ b/guess-language.el
@@ -147,8 +147,8 @@ Uses ISO 639-1 to identify languages.")
   "Compile regular expressions used for guessing language."
   (setq guess-language--regexps
         (cl-loop
-         for lang in (guess-language-load-trigrams)
-         collect (cons (car lang) (regexp-opt (cdr lang))))))
+         for (lang . regexps) in (guess-language-load-trigrams)
+         collect (cons lang (regexp-opt regexps)))))
 
 (defun guess-language-backward-paragraph ()
   "Uses whatever method for moving to the previous paragraph is
@@ -181,9 +181,8 @@ Region starts at BEGINNING and ends at END."
   (when (cl-set-exclusive-or guess-language-languages (mapcar #'car guess-language--regexps))
     (guess-language-compile-regexps))
   (let ((tally (cl-loop
-                for lang in guess-language--regexps
-                for regexp = (cdr lang)
-                collect (cons (car lang) (how-many regexp beginning end)))))
+                for (lang . regexp) in guess-language--regexps
+                collect (cons lang (how-many regexp beginning end)))))
     (car (cl-reduce (lambda (x y) (if (> (cdr x) (cdr y)) x y)) tally))))
 
 (defun guess-language-buffer ()


### PR DESCRIPTION
I believe this is a more idiomatic use. At least it is shorter in these cases.

I read through the code and was actually quite surprised by the `for VAR = STATEMENT` clauses, since I had learned from the manual that `for VAR =` is for iteration, but of course it works as iterating one time.

By the way, applied this on top of my other pull-request, since I believe you should pull that as well 😊.