### PR TITLE
Use idle-timer to trigger flyspell

### DIFF
--- a/guess-language.el
+++ b/guess-language.el
@@ -248,14 +248,14 @@ which LANG was detected."
       ;; from flyspell-incorrect-hook that called us. Otherwise, the
       ;; word at point is highlighted as incorrect even if it is
       ;; correct according to the new dictionary.
-      (run-at-time 0 nil
-                   (lambda ()
-                     (let ((flyspell-issue-welcome-flag nil)
-                           (flyspell-issue-message-flag nil)
-                           (flyspell-incorrect-hook nil)
-                           (flyspell-large-region 1))
-                       (with-local-quit
-                         (flyspell-region beginning end))))))))
+      (run-with-idle-timer 0 nil
+                           (lambda ()
+                             (let ((flyspell-issue-welcome-flag nil)
+                                   (flyspell-issue-message-flag nil)
+                                   (flyspell-incorrect-hook nil)
+                                   (flyspell-large-region 1))
+                               (with-local-quit
+                                 (flyspell-region beginning end))))))))
 
 (defun guess-language-switch-typo-mode-function (lang _beginning _end)
   "Switch the language used by typo-mode.


### PR DESCRIPTION
I experience freezing buffers after switching to `guess-language`. Unfortunately I can't present a simple reproducible example.  But I think it might be related to what was discussed in #26.

Sometimes loading a file using a mode that enables `guess-language` and `flyspell` just hangs.  I have to "C-g" and then the buffer appears as it should be.  I believe it is caused by some other code (e.g. font-lock) or packages (e.g. yasnippet) in combination with the `guess-language` code.  Obviously this makes it difficult for you to find the issue.

One of the things I tried was replacing the `run-at-time` call with `run-with-idle-timer`.  Indeed it seemed to have solved my problem!

I tried to find out the difference and someone on the Emacs Help mailing list helped to create an example explaining the difference of these two functions.  Run the following code and look at the *Messages* buffer:

```
(progn
  (message "start")
  (run-at-time 0 nil 'message "running at time")
  (run-with-idle-timer 0 nil 'message "running at idle time")
  (redisplay)                           ; (sit-for 0)
  (message "after redisplay")
  (message ""))
```

The "running at time" message will appear before the "after redisplay" message while "running at idle time" will appear later. `redisplay` will cause the `run-at-time` timer to run!

My explanation for my problem: your code currently uses the `run-at-time` function to trigger flycheck.  At least one of the packages I use has a call to `redisplay` or a similar function which causes the timer to execute the lambda.  Unfortunately the buffer or the `hunspell` process is not ready at this point and that somehow causes the freeze for me.

Switching to `run-with-idle-timer` would only run the timer if Emacs becomes idle (meaning: waiting for user input).  As I understand this is what you are trying to do here.