### PR TITLE
QoL improvements

### DIFF
--- a/guess-language.el
+++ b/guess-language.el
@@ -330,12 +330,18 @@ correctly."
   ;; The initial value.
   :init-value nil
   ;; The indicator for the mode line.
-  :lighter (:eval (format " %s" (or
-                                 (nth 3 (assq guess-language-current-language guess-language-langcodes))
-                                 ;; Options for users of old configurations:
-                                 (nth 2 (assq guess-language-current-language guess-language-langcodes))
-                                 (nth 1 (assq guess-language-current-language guess-language-langcodes))
-                                 "default")))
+  :lighter (:eval (format " %s"
+                   ;; Assume default language is the first in languages list
+                   (let* ((language-to-show (or
+                                             guess-language-current-language
+                                             (car guess-language-languages)))
+                          (entry (assq language-to-show guess-language-langcodes)))
+                     (or
+                      (nth 3 entry)
+                      ;; Options for users of old configurations:
+                      (nth 2 entry)
+                      (nth 1 entry)
+                      "No langs"))))
   :global nil
   (if guess-language-mode
       (progn

--- a/guess-language.el
+++ b/guess-language.el
@@ -232,8 +232,7 @@ things like changing the keyboard layout or input method."
     (when (> (- end beginning) guess-language-min-paragraph-length)
       (let ((lang (guess-language-region beginning end)))
         (run-hook-with-args 'guess-language-after-detection-functions lang beginning end)
-        (setq guess-language-current-language lang)
-        (message (format "Detected language: %s" (nth 4 (assoc lang guess-language-langcodes))))))))
+        (setq guess-language-current-language lang)))))
 
 (defun guess-language--idle-begin (buf win tick beginning)
   "Run guess-langauge unless we left or changed the current paragraph."


### PR DESCRIPTION
This pull request introduces two small enhancements to guess-language.

First, it allows users to customize the mode-line string when the default dictionary is used. The variable used for this is `guess-language-mode-line-string`, which defaults to `"default"`. It can be used to translate the `"default"` string, or it can be set to `nil` to show no mode if no language is detected.

Second, the `guess-language-issue-message-flag` variable has been added to control the issuing of messages. If this variable is nil, no messages will be issued. Currently, this setting only affects the `Detected language: ...` string.